### PR TITLE
Add a poly-only mGB mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Arduinoboy/Arduinoboy.ino.TEENSYLC.hex

--- a/Arduinoboy/Arduinoboy.ino
+++ b/Arduinoboy/Arduinoboy.ino
@@ -39,7 +39,7 @@
  *     - Serial Data from gameboy on analog in pin 18                      *
  *                                                                         *
  *   Teensy USB MIDI is supported                                          *
- *   Teensy LC should work but untested                                    *
+ *   Teensy LC works                                                       *
  *                                                                         *
  * Program Information:                                                    *
  *    LSDJ Slave Mode Midi Note Effects:                                   *
@@ -77,7 +77,7 @@
  ***************************************************************************/
 #include <EEPROM.h>
 #define MEM_MAX 65
-#define NUMBER_OF_MODES 7    //Right now there are 7 modes, Might be more in the future
+#define NUMBER_OF_MODES 8    //Right now there are 8 modes, Might be more in the future
 
 //!!! do not edit these, they are the position in EEPROM memory that contain the value of each stored setting
 #define MEM_CHECK 0
@@ -452,8 +452,3 @@ void loop () {
   setMode();
   switchMode();
 }
-
-
-
-
-

--- a/Arduinoboy/Led_Functions.ino
+++ b/Arduinoboy/Led_Functions.ino
@@ -30,6 +30,10 @@ void showSelectedMode()
         digitalWrite(pinLeds[4],HIGH);
         digitalWrite(pinLeds[5],HIGH);
         break;
+      case 7:
+        digitalWrite(pinLeds[0],HIGH);
+        digitalWrite(pinLeds[4],HIGH);
+        break;
 
     }
   delay(100);
@@ -243,25 +247,3 @@ void startupSequence()
   delay(500);
 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/Arduinoboy/Mode.ino
+++ b/Arduinoboy/Mode.ino
@@ -18,7 +18,7 @@
  /*
    setMode will check if the push button is depressed, If it is it will 
    increment the mode number and make sure its in the 
-   range 0 to 4 by mod (%). It will then write the mode to memory,
+   range 0 to 7. It will then write the mode to memory,
    set the leds to display the mode, and switch the code over to the
    right function.
  */
@@ -30,7 +30,7 @@ void setMode()
   if(!memory[MEM_FORCE_MODE] && buttonDepressed) { //if the button is pressed
     memory[MEM_MODE]++;                           //increment the mode number
     if(memory[MEM_MODE] > (NUMBER_OF_MODES - 1)) memory[MEM_MODE]=0;  //if the mode is greater then 4 it will wrap back to 0
-    if(!memory[MEM_FORCE_MODE]) EEPROM.write(MEM_MODE, memory[MEM_MODE]); //write mode to eeprom if we arnt forcing a mode in the config
+    if(!memory[MEM_FORCE_MODE]) EEPROM.write(MEM_MODE, memory[MEM_MODE]); //write mode to eeprom if we aren't forcing a mode in the config
     showSelectedMode();            //set the LEDS
     switchMode();
   }
@@ -59,6 +59,7 @@ void switchMode()
       modeNanoloopSetup();
       break;
     case 4:
+    case 7:
       modeMidiGbSetup();
       break;
     case 5:
@@ -110,27 +111,3 @@ void sequencerStop()
   digitalWrite(pinLeds[3],LOW);
   digitalWrite(pinLeds[memory[MEM_MODE]],HIGH);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/Arduinoboy/Mode_MidiGb.ino
+++ b/Arduinoboy/Mode_MidiGb.ino
@@ -45,7 +45,11 @@ void modeMidiGb()
             sendByte = false;
             midiStatusChannel = incomingMidiByte&0x0F;
             midiStatusType    = incomingMidiByte&0xF0;
-            if(midiStatusChannel == memory[MEM_MGB_CH]) {
+            if (memory[MEM_MODE] == 7  // All-Poly mGB Mode
+                  || midiStatusChannel == memory[MEM_MGB_CH+4]) {
+               midiData[0] = midiStatusType+4;
+               sendByte = true;
+            } else if(midiStatusChannel == memory[MEM_MGB_CH]) {
                midiData[0] = midiStatusType;
                sendByte = true;
             } else if (midiStatusChannel == memory[MEM_MGB_CH+1]) {
@@ -56,9 +60,6 @@ void modeMidiGb()
                sendByte = true;
             } else if (midiStatusChannel == memory[MEM_MGB_CH+3]) {
                midiData[0] = midiStatusType+3;
-               sendByte = true;
-            } else if (midiStatusChannel == memory[MEM_MGB_CH+4]) {
-               midiData[0] = midiStatusType+4;
                sendByte = true;
             } else {
               midiValueMode  =false;
@@ -126,7 +127,11 @@ void modeMidiGbUsbMidiReceive()
     while(usbMIDI.read()) {
         uint8_t ch = usbMIDI.getChannel() - 1;
         boolean send = false;
-        if(ch == memory[MEM_MGB_CH]) {
+        if (memory[MEM_MODE] == 7  // All-Poly mGB Mode
+                || ch == memory[MEM_MGB_CH+4]) {
+            ch = 4;
+            send = true;
+        } else if(ch == memory[MEM_MGB_CH]) {
             ch = 0;
             send = true;
         } else if (ch == memory[MEM_MGB_CH+1]) {
@@ -137,9 +142,6 @@ void modeMidiGbUsbMidiReceive()
             send = true;
         } else if (ch == memory[MEM_MGB_CH+3]) {
             ch = 3;
-            send = true;
-        } else if (ch == memory[MEM_MGB_CH+4]) {
-            ch = 4;
             send = true;
         }
         if(!send) return;
@@ -189,6 +191,3 @@ void modeMidiGbUsbMidiReceive()
     }
 #endif
 }
-
-
-

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ In LSDJ the `sync` mode should be set to `Midiout`.
 
 *This requires a special version of LSDJ, which can be found in your account on the [LSDJ website](http://littlesounddj.com/lsd/latest/full_version/).*
 
+#### Mode 8 Poly-only Full MIDI with mGB
+
+This is useful for polyphony on musical keyboards that can't change MIDI channels.
+
 
 ## Max Editor
 ![Editor gui](Editor/editor.png)


### PR DESCRIPTION
Adds a Polyphonic-only mGB mode for users of musical keyboards [that can't change MIDI channel](https://www.youtube.com/watch?v=c2-QXARQN3o&t=8m08s) (which is most inexpensive keyboards currently in production, I believe.)

Also, minor comment edits.

Thanks for the awesome hardware!